### PR TITLE
Remove ARM architecture from Windows 11 build

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,8 +34,6 @@ jobs:
             os: windows-latest
           - architecture: amd64
             os: windows-latest
-          - architecture: arm
-            os: windows-11-arm
           - architecture: arm64
             os: windows-11-arm
     steps:


### PR DESCRIPTION
Removed ARM architecture build for Windows 11.