### PR TITLE
Remove version pinning from RedHat.Podman

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -89,7 +89,6 @@ jobs:
         run: |
           winget install --exact `
             --id RedHat.Podman `
-            --version "5.7.1" `
             --source winget `
             --accept-package-agreements `
             --accept-source-agreements `
@@ -177,7 +176,6 @@ jobs:
         run: |
           winget install --exact `
             --id RedHat.Podman `
-            --version "5.7.1" `
             --source winget `
             --accept-package-agreements `
             --accept-source-agreements `


### PR DESCRIPTION
apparently winget is not suited for pinned versions. Will investigate alternatives later, but for now, the workflow should work again.